### PR TITLE
chore: pin pre-commit hooks to commit SHAs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v6.0.0
+    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c  # v6.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -11,7 +11,7 @@ repos:
       - id: check-merge-conflict
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.4
+    rev: a27a2e47c7751b639d2b5badf0ef6ff11fee893f  # v0.15.4
     hooks:
       - id: ruff
         args: [--no-fix]
@@ -19,7 +19,7 @@ repos:
         args: [--check]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.19.1
+    rev: a66e98df7b4aeeb3724184b332785976d062b92e  # v1.19.1
     hooks:
       - id: mypy
         args: [--strict, src/navi_fractal/]


### PR DESCRIPTION
## Summary
- Replace mutable version tags with immutable commit SHAs in `.pre-commit-config.yaml`
- Prevents supply-chain attacks from tag rewriting
- Version tags preserved in comments for readability

| Hook | Version | SHA |
|---|---|---|
| pre-commit-hooks | v6.0.0 | `3e8a8703` |
| ruff-pre-commit | v0.15.4 | `a27a2e47` |
| mirrors-mypy | v1.19.1 | `a66e98df` |

## Test plan
- [ ] `pre-commit run --all-files` passes with SHA-pinned hooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)