### PR TITLE
fix: match spotlight to project-navi-site reference spec

### DIFF
--- a/docs/stylesheets/navi.css
+++ b/docs/stylesheets/navi.css
@@ -215,14 +215,15 @@ body {
 .md-content .hero-glow::before {
   content: '';
   position: absolute;
-  top: -60px;
-  left: -10%;
-  right: -10%;
-  height: 400px;
+  top: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 150%;
+  height: 100%;
   background: radial-gradient(
     ellipse at center top,
     rgba(126, 184, 168, 0.08) 0%,
-    transparent 70%
+    transparent 50%
   );
   pointer-events: none;
   z-index: -1;


### PR DESCRIPTION
## Summary
- Match hero glow spotlight CSS to the canonical project-navi-site pillar.css spec
- Replaces #7 which had merge conflicts from stale branch history

## Test plan
- [ ] Verify spotlight renders identically to project-navi.github.io main site

🤖 Generated with [Claude Code](https://claude.com/claude-code)